### PR TITLE
Fix problem with minibuffer commands.

### DIFF
--- a/auto-indent-mode.el
+++ b/auto-indent-mode.el
@@ -4731,6 +4731,10 @@ around and the whitespace was deleted from the line."
               (indent-according-to-mode))))))
     (error (message "[Auto-Indent-Mode]: Ignored indentation error in `auto-indent-mode-post-command-hook' %s" (error-message-string err)))))
 
+(defun auto-indent-minibuffer-hook ()
+  (setq auto-indent-last-pre-command-hook-minibufferp t))
+(add-hook 'minibuffer-setup-hook #'auto-indent-minibuffer-hook)
+
 (defvar auto-indent-was-on nil)
 
 (provide 'auto-indent-mode)


### PR DESCRIPTION
When executing the pre-command hook, (minibufferp) is not yet t; in
post-command-hook it is no longer t.  This means that typing e.g. M-x
ignore RET will cause the current line to be reindented, because
post-command-hook thinks that the last command was (non-minibuffer)
return.  Thus, we should set
auto-indent-last-pre-command-hook-minibufferp whenever the minibuffer is
entered, and not just in the pre-command hook.

One can observe this issue by opening a buffer with auto-indent-mode on,
changing the indentation of a line to be incorrect, then running M-x
ignore; the line should reindent.  In practice, this is an issue for
python code like the following:

```
if condition:
    do_something()

something_else()
```

Executing a minibuffer command with point on the something_else line
will cause that line to be indented into the conditional.
