### PR TITLE
Ensuring that the write-contents-hook returns nil

### DIFF
--- a/auto-indent-mode.el
+++ b/auto-indent-mode.el
@@ -1961,7 +1961,8 @@ buffer."
         (tabify (point-min) (point-max)))
        ((or (and (not save) auto-indent-untabify-on-visit-file)
             (and save auto-indent-untabify-on-save-file))
-        (untabify (point-min) (point-max)))))))
+        (untabify (point-min) (point-max))))
+      nil)))
 
 (defun auto-indent-file-when-save ()
   "Auto-indent file when save."


### PR DESCRIPTION
The auto-indent-whole-buffer was being called in a
write-contents-hook. It is important for a write-contents-hook to return
nil since according to the documentation if any function in the hook
returns a non-nil the file is considered already written and the rest of
the functions are not called and neither are the functions in
write-file-functions.

fixes #38
