### PR TITLE
Fix extra nil argument to `looking-at`

### DIFF
--- a/README.org
+++ b/README.org
@@ -289,7 +289,7 @@ you do not want this to happen you can turn it off by
 #+END_SRC
 
 ** Why is auto-indent-mode changing tabs to spaces
-I prefer tabs instead of spaces.  You may prefer the other way.  The
+I prefer spaces instead of tabs.  You may prefer the other way.  The
 options to change this are:
 
 #+BEGIN_SRC emacs-lisp

--- a/auto-indent-mode.el
+++ b/auto-indent-mode.el
@@ -2623,7 +2623,7 @@ around and the whitespace was deleted from the line."
                  auto-indent-mode-pre-command-hook-line
                  (not (= (line-number-at-pos)
                          auto-indent-mode-pre-command-hook-line)))
-            (when (and (looking-back "^[ \t]*" nil) (looking-at "[ \t]*$" nil))
+            (when (and (looking-back "^[ \t]*" nil) (looking-at "[ \t]*$"))
               ;; Should be conservative here.
               (auto-indent-according-to-mode))))))
     (error (message "[Auto-Indent-Mode]: Ignored indentation error in `auto-indent-mode-post-command-hook' %s" (error-message-string err)))))


### PR DESCRIPTION
In Emacs 25.1, `looking-at` only takes one argument. This caused a lot of:

```
[Auto-Indent-Mode]: Ignored indentation error in ‘auto-indent-mode-post-command-hook’ Wrong number of arguments: looking-at, 2
```

Whenever auto-indent-mode is enabled.

Also fixes a typo in README.org